### PR TITLE
Fix Triple Deduplication Problem in models/constructor/kt_gen

### DIFF
--- a/models/constructor/kt_gen.py
+++ b/models/constructor/kt_gen.py
@@ -518,11 +518,12 @@ class KTBuilder:
         for node, node_data in self.graph.nodes(data=True):
             new_graph.add_node(node, **node_data)
 
-        seen_keys = set()
+        seen_triples = set()
         for u, v, key, data in self.graph.edges(keys=True, data=True):
-            if (u, v, key) not in seen_keys:
-                seen_keys.add((u, v, key))
-                new_graph.add_edge(u, v, key=key, **data)
+            relation = data.get('relation') 
+            if (u, v, relation) not in seen_triples:
+                seen_triples.add((u, v, relation))
+                new_graph.add_edge(u, v, **data)
         self.graph = new_graph
 
     def format_output(self) -> List[Dict[str, Any]]:


### PR DESCRIPTION
非常棒的项目！很受启发！
但我在阅读代码的时候发现一个潜在的问题。
在 `/models/constructor/kt_gen.py` 文件中的 `triple_deduplicate` 函数，看起来是想实现对最初图谱中冗余的边进行过滤。
但由于 `nx.MultiDiGraph()` 本身是多重有向图，允许两个节点之间存在多条平行的边，所以当进行边的遍历时，key会自动为这些平行边进行分配唯一标识符，所以会导致 `if (u, v, key) not in seen_keys:` 这个条件永远为真。
我写了一个简单的例子证明，结果如下：
<img width="1594" height="726" alt="image" src="https://github.com/user-attachments/assets/cf275dbc-c818-4ca2-aa6a-7536a1beba72" />


所以我认为使用关系的话会更好一点，您觉得怎么样。