### PR TITLE
# refactor: Check for embedding model consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ wheels/
 data/
 output/
 
-retriever/faiss_cache_new/*
+# retriever/faiss_cache_new/*
 docker/Dockerfile

--- a/models/retriever/enhanced_kt_retriever.py
+++ b/models/retriever/enhanced_kt_retriever.py
@@ -1,3 +1,4 @@
+import json
 import os
 import pickle
 import threading
@@ -397,7 +398,16 @@ class KTRetriever:
             return False
 
     def _load_node_embedding_cache(self):
+        """Check if node embedding cache exists and matches the current model"""
         """Load node embedding cache from disk"""
+        embedding_model_info = f"{self.cache_dir}/{self.dataset}/embedding_model_info.json"
+        if os.path.exists(embedding_model_info):
+            with open(embedding_model_info, 'r') as f:
+                embedding_model_info = json.load(f)
+            if embedding_model_info['model_name'] != self.config.embeddings.model_name:
+                return False
+        else:
+            return False
         cache_path = f"{self.cache_dir}/{self.dataset}/node_embedding_cache.pt"
         cache_path_npz = cache_path.replace('.pt', '.npz')
         

--- a/retriever/faiss_cache_new/demo/embedding_model_info.json
+++ b/retriever/faiss_cache_new/demo/embedding_model_info.json
@@ -1,0 +1,3 @@
+{
+    "model_name": "all-MiniLM-L6-v2"
+}


### PR DESCRIPTION
# refactor: Check for embedding model consistency

This pull request introduces a check to ensure that the embedding model used during inference is consistent with the model used when creating the index.

**Changes:**

- In `enhanced_kt_retriever.py`, the `_load_node_embedding_cache` method now checks for an `embedding_model_info.json` file and compares the model name.
- In `faiss_filter.py`, the dimension transformation logic has been removed, and the `build_indices` method now checks for `embedding_model_info.json` and its consistency.
- A new method `_save_embedding_model_info` has been added to save the embedding model name.

These changes prevent the use of inconsistent embeddings, which could lead to unexpected behavior.