### PR TITLE
[Azure]添加对Azure OpenAI的支持

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@
 LLM_MODEL=deepseek-chat
 LLM_BASE_URL=https://api.deepseek.com
 LLM_API_KEY=sk-xxxxxx
+API_VERSION=
+OPENAI_PROVIDER=

--- a/utils/call_llm_api.py
+++ b/utils/call_llm_api.py
@@ -4,7 +4,7 @@ import json
 import requests
 import re
 
-from openai import OpenAI
+from openai import OpenAI, AzureOpenAI
 from dotenv import load_dotenv
 
 from utils.logger import logger
@@ -18,7 +18,16 @@ class LLMCompletionCall:
         self.llm_api_key = os.getenv("LLM_API_KEY", "")
         if not self.llm_api_key:
             raise ValueError("LLM API key not provided")
-        self.client = OpenAI(base_url=self.llm_base_url, api_key = self.llm_api_key)
+        self.openai_provider = os.getenv("OPENAI_PROVIDER", "openai").lower()
+        if self.openai_provider == "azure":
+            self.api_version = os.getenv("API_VERSION", "2025-01-01-preview")
+            self.client = AzureOpenAI(
+                    azure_endpoint=self.llm_base_url,
+                    api_key=self.llm_api_key,
+                    api_version=self.api_version,
+                )
+        else:
+            self.client = OpenAI(base_url=self.llm_base_url, api_key = self.llm_api_key)
 
     def call_api(self, content: str) -> str:
         """


### PR DESCRIPTION
[Azure]添加对Azure OpenAI的支持
This pull request introduces support for Azure OpenAI as an alternative provider for the LLM API, allowing the system to flexibly switch between OpenAI and Azure OpenAI based on environment configuration. It also updates environment variable management to enable this feature.

Provider configuration enhancements:

* Added `OPENAI_PROVIDER` and `API_VERSION` environment variables to `.env.example` to allow selection between OpenAI and Azure OpenAI, and to specify API version for Azure.
* Updated `utils/call_llm_api.py` to import `AzureOpenAI` and configure the client based on the `OPENAI_PROVIDER` environment variable, initializing `AzureOpenAI` with the appropriate endpoint, API key, and version when Azure is selected. [[1]](diffhunk://#diff-69102d8bf8c8fd1a059125e72859a1ecbc152ccfb003ede7de10fdeafffd7349L7-R7) [[2]](diffhunk://#diff-69102d8bf8c8fd1a059125e72859a1ecbc152ccfb003ede7de10fdeafffd7349R21-R29)