### PR TITLE
[codex] Restrict schema type filtering to matching nodes

### DIFF
--- a/models/retriever/enhanced_kt_retriever.py
+++ b/models/retriever/enhanced_kt_retriever.py
@@ -778,9 +778,6 @@ class KTRetriever:
             
             if node_schema_type in target_types:
                 filtered_nodes.append(node_id)
-            # Also include nodes without schema_type for backward compatibility
-            elif not node_schema_type and node_data.get('label') == 'entity':
-                filtered_nodes.append(node_id)
 
         return filtered_nodes
 

--- a/tests/test_enhanced_kt_retriever.py
+++ b/tests/test_enhanced_kt_retriever.py
@@ -1,0 +1,42 @@
+import unittest
+
+import networkx as nx
+
+from models.retriever.enhanced_kt_retriever import KTRetriever
+
+
+class SchemaTypeFilteringTest(unittest.TestCase):
+    def setUp(self):
+        self.retriever = KTRetriever.__new__(KTRetriever)
+        self.retriever.graph = nx.Graph()
+        self.retriever.graph.add_node(
+            "person_1",
+            label="entity",
+            properties={"schema_type": "person"},
+        )
+        self.retriever.graph.add_node(
+            "movie_1",
+            label="entity",
+            properties={"schema_type": "creative_work"},
+        )
+        self.retriever.graph.add_node(
+            "legacy_entity",
+            label="entity",
+            properties={},
+        )
+
+    def test_empty_target_types_keep_full_graph_fallback(self):
+        self.assertCountEqual(
+            self.retriever._filter_nodes_by_schema_type([]),
+            ["person_1", "movie_1", "legacy_entity"],
+        )
+
+    def test_target_types_exclude_untyped_entities(self):
+        self.assertEqual(
+            self.retriever._filter_nodes_by_schema_type(["person"]),
+            ["person_1"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes #149 by excluding untyped entity nodes when schema target types are provided.
- Keeps the existing full-graph fallback when no target types are provided.
- Adds a focused unittest for both filtering paths.

## Why
The previous compatibility fallback added every entity without a schema_type into type-filtered retrieval. On graphs with many legacy or untyped entities, this made typed retrieval much broader than requested and could return too many nodes.

## Validation
- .venv\\Scripts\\python.exe -m unittest tests.test_enhanced_kt_retriever